### PR TITLE
Add deck preview panel and virtualized card grid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,9 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^7.8.0",
+        "react-virtualized-auto-sizer": "*",
+        "react-window": "*",
+        "recharts": "*",
         "zustand": "^5.0.7"
       },
       "devDependencies": {
@@ -1334,6 +1337,32 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.8.2.tgz",
+      "integrity": "sha512-MYlOhQ0sLdw4ud48FoC5w0dH9VfWQjtCjreKwYTT3l+r427qYC5Y8PihNutepr8XrNaBUDQo9khWUwQxZaqt5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^10.0.3",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1620,6 +1649,18 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.1.11",
@@ -1952,6 +1993,69 @@
         "@types/deep-eql": "*"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -2005,6 +2109,12 @@
       "peerDependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -2362,6 +2472,127 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -2378,6 +2609,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
@@ -2458,6 +2695,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/es-toolkit": {
+      "version": "1.39.8",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.39.8.tgz",
+      "integrity": "sha512-A8QO9TfF+rltS8BXpdu8OS+rpGgEdnRhqIVxO/ZmNvnXBYgOdSsxukT55ELyP94gZIntWJ+Li9QRrT2u1Kitpg==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
     "node_modules/esbuild": {
       "version": "0.25.8",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.8.tgz",
@@ -2531,6 +2778,12 @@
       "dependencies": {
         "@types/estree": "^1.0.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
     },
     "node_modules/expect-type": {
       "version": "1.2.2",
@@ -2685,6 +2938,16 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/immer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
+      "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -2699,6 +2962,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-arrayish": {
@@ -3062,6 +3334,12 @@
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "license": "MIT"
+    },
     "node_modules/minipass": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -3332,6 +3610,29 @@
       "integrity": "sha512-tr41fA15Vn8p4X9ntI+yCyeGSf1TlYaY5vlTZfQmeLBrFo3psOPX6HhTDnFNL9uj3EhP0KAQ80cugCl4b4BERA==",
       "license": "MIT"
     },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -3395,6 +3696,81 @@
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
       }
+    },
+    "node_modules/react-virtualized-auto-sizer": {
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.26.tgz",
+      "integrity": "sha512-CblNyiNVw2o+hsa5/49NH2ogGxZ+t+3aweRvNSq7TVjDIlwk7ir4lencEg5HxHeSzwNarSkNkiu0qJSOXtxm5A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-window": {
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz",
+      "integrity": "sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
+      },
+      "engines": {
+        "node": ">8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.1.2.tgz",
+      "integrity": "sha512-vhNbYwaxNbk/IATK0Ki29k3qvTkGqwvCgyQAQ9MavvvBwjvKnMTswdbklJpcOAoMPN/qxF3Lyqob0zO+ZXkZ4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.10",
@@ -3623,6 +3999,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -3753,6 +4135,37 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,10 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^7.8.0",
-    "zustand": "^5.0.7"
+    "zustand": "^5.0.7",
+    "react-window": "*",
+    "react-virtualized-auto-sizer": "*",
+    "recharts": "*"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.11",

--- a/public/art/aurora-bg.svg
+++ b/public/art/aurora-bg.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1920" height="1080" viewBox="0 0 1920 1080">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#0b1e39"/>
+      <stop offset="100%" stop-color="#1b4366"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="0%" r="70%">
+      <stop offset="0%" stop-color="#a5b4fc" stop-opacity="0.6"/>
+      <stop offset="100%" stop-color="#0b1e39" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#grad)"/>
+  <rect width="100%" height="100%" fill="url(#glow)"/>
+</svg>

--- a/public/art/card-ph.svg
+++ b/public/art/card-ph.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="420" viewBox="0 0 300 420">
+  <rect width="300" height="420" rx="12" ry="12" fill="#1e293b"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="#94a3b8" font-size="20" font-family="sans-serif">No Image</text>
+</svg>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,17 +11,24 @@ import About from './routes/About';
 export default function App() {
   return (
     <BrowserRouter>
-      <Header />
-      <Container maxWidth="xl" sx={{ py: 2 }}>
-        <Routes>
-          <Route path="/" element={<Home />} />
-          <Route path="/cards" element={<Cards />} />
-          <Route path="/card/:id" element={<CardDetails />} />
-          <Route path="/builder" element={<Builder />} />
-          <Route path="/decks" element={<Decks />} />
-          <Route path="/about" element={<About />} />
-        </Routes>
-      </Container>
+      <div className="min-h-screen">
+        <div
+          aria-hidden
+          className="fixed inset-0 -z-10 bg-cover bg-center"
+          style={{ backgroundImage: "url(/art/aurora-bg.svg)" }}
+        />
+        <Header />
+        <Container maxWidth="xl" sx={{ py: 2 }}>
+          <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/cards" element={<Cards />} />
+            <Route path="/card/:id" element={<CardDetails />} />
+            <Route path="/builder" element={<Builder />} />
+            <Route path="/decks" element={<Decks />} />
+            <Route path="/about" element={<About />} />
+          </Routes>
+        </Container>
+      </div>
     </BrowserRouter>
   );
 }

--- a/src/components/CardGrid.tsx
+++ b/src/components/CardGrid.tsx
@@ -1,17 +1,48 @@
-import CardFrame from './CardFrame';
 import type { Card } from '../types';
+import CardTile from './CardTile';
+import { FixedSizeGrid as Grid, GridChildComponentProps } from 'react-window';
+import AutoSizer from 'react-virtualized-auto-sizer';
 
 interface Props {
   cards: Card[];
-  deckId?: number;
+  counts: (id: number) => number;
 }
 
-export default function CardGrid({ cards, deckId }: Props) {
+const CARD_W = 180;
+const CARD_H = 260;
+
+export default function CardGrid({ cards, counts }: Props) {
+  const Cell = ({ columnIndex, rowIndex, style, data }: GridChildComponentProps) => {
+    const { cards, columnCount } = data;
+    const index = rowIndex * columnCount + columnIndex;
+    if (index >= cards.length) return null;
+    const card = cards[index];
+    return (
+      <div style={style} className="p-2">
+        <CardTile card={card} count={counts(card.id)} />
+      </div>
+    );
+  };
+
   return (
-    <div className="grid gap-4 grid-cols-[repeat(auto-fill,minmax(150px,1fr))]">
-      {cards.map(c => (
-        <CardFrame card={c} key={c.id} deckId={deckId} />
-      ))}
-    </div>
+    <AutoSizer>
+      {({ width, height }) => {
+        const columnCount = Math.max(1, Math.floor(width / CARD_W));
+        const rowCount = Math.ceil(cards.length / columnCount);
+        return (
+          <Grid
+            columnCount={columnCount}
+            columnWidth={CARD_W}
+            height={height}
+            rowCount={rowCount}
+            rowHeight={CARD_H}
+            width={width}
+            itemData={{ cards, columnCount }}
+          >
+            {Cell}
+          </Grid>
+        );
+      }}
+    </AutoSizer>
   );
 }

--- a/src/components/CardTile.tsx
+++ b/src/components/CardTile.tsx
@@ -1,36 +1,33 @@
 import { Card as CardType } from '../types';
 import { Card, CardMedia, CardActions, IconButton, Chip, Stack } from '@mui/material';
-import AddIcon from '@mui/icons-material/Add';
 import RemoveIcon from '@mui/icons-material/Remove';
+import { useDecks } from '../store/useDecks';
 
 interface Props {
   card: CardType;
   count: number;
-  onAdd: (id: number) => void;
-  onRemove: (id: number) => void;
 }
 
-export default function CardTile({ card, count, onAdd, onRemove }: Props) {
+export default function CardTile({ card, count }: Props) {
+  const { addToSelectedOrPrompt, dec, selectedDeckId } = useDecks();
+  const handleRemove = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (selectedDeckId) dec(selectedDeckId, card.id);
+  };
+  const src = card.image_url || (card as any).image || '/art/card-ph.svg';
   return (
-    <Card sx={{ position: 'relative' }}>
-      {card.image_url ? (
-        <CardMedia component="img" image={card.image_url} alt={card.name} loading="lazy" />
-      ) : (
-        <CardMedia component="div" sx={{ height: 140, bgcolor: 'grey.800' }} />
-      )}
-      <CardActions sx={{ position: 'absolute', bottom: 0, right: 0 }}>
-        <Stack direction="row" spacing={0.5} alignItems="center">
-          {count > 0 && <Chip label={count} color="primary" size="small" />}
-          <IconButton color="primary" size="small" onClick={() => onAdd(card.id)}>
-            <AddIcon fontSize="small" />
-          </IconButton>
-          {count > 0 && (
-            <IconButton color="primary" size="small" onClick={() => onRemove(card.id)}>
+    <Card sx={{ position: 'relative', cursor: 'pointer' }} onClick={() => addToSelectedOrPrompt(card)}>
+      <CardMedia component="img" image={src} alt={card.name} loading="lazy" width={300} height={420} />
+      {count > 0 && (
+        <CardActions sx={{ position: 'absolute', bottom: 0, right: 0 }}>
+          <Stack direction="row" spacing={0.5} alignItems="center">
+            <Chip label={count} color="primary" size="small" />
+            <IconButton color="primary" size="small" onClick={handleRemove}>
               <RemoveIcon fontSize="small" />
             </IconButton>
-          )}
-        </Stack>
-      </CardActions>
+          </Stack>
+        </CardActions>
+      )}
     </Card>
   );
 }

--- a/src/components/DeckPreview.tsx
+++ b/src/components/DeckPreview.tsx
@@ -1,0 +1,56 @@
+import { Box, Chip, IconButton, Stack, Typography } from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import RemoveIcon from '@mui/icons-material/Remove';
+import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis } from 'recharts';
+import { useDecks } from '../store/useDecks';
+
+export default function DeckPreview() {
+  const { selectedDeckId, deckCards, inc, dec, stats } = useDecks();
+  const rows = deckCards(selectedDeckId || undefined);
+  const s = stats();
+
+  return (
+    <Box sx={{ p: 2, width: 300 }}>
+      <Typography variant="h6" gutterBottom>
+        Deck ({s.total})
+      </Typography>
+      <Stack spacing={1} mb={2}>
+        {rows.map(r => (
+          <Stack key={r.cardId} direction="row" justifyContent="space-between" alignItems="center">
+            <Typography variant="body2" sx={{ flex: 1 }} noWrap>
+              {r.snapshot.name}
+            </Typography>
+            <Stack direction="row" spacing={0.5} alignItems="center">
+              <IconButton size="small" onClick={() => dec(selectedDeckId!, Number(r.cardId))}>
+                <RemoveIcon fontSize="small" />
+              </IconButton>
+              <Chip label={r.count} size="small" />
+              <IconButton size="small" onClick={() => inc(selectedDeckId!, r.snapshot)}>
+                <AddIcon fontSize="small" />
+              </IconButton>
+            </Stack>
+          </Stack>
+        ))}
+        {rows.length === 0 && <Typography variant="body2">No cards</Typography>}
+      </Stack>
+      <Stack direction="row" spacing={1} mb={2}>
+        <Chip label={`Inkable ${s.inkable}`} color="primary" size="small" />
+        <Chip label={`Uninkable ${s.uninkable}`} color="secondary" size="small" />
+      </Stack>
+      <Stack direction="row" spacing={1} flexWrap="wrap" mb={2}>
+        {Object.entries(s.types).map(([t, c]) => (
+          <Chip key={t} label={`${t} ${c}`} size="small" />
+        ))}
+      </Stack>
+      <Box sx={{ height: 120 }}>
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={s.curve}>
+            <XAxis dataKey="cost" />
+            <YAxis allowDecimals={false} />
+            <Bar dataKey="count" fill="#8884d8" />
+          </BarChart>
+        </ResponsiveContainer>
+      </Box>
+    </Box>
+  );
+}

--- a/src/data/lorcana.ts
+++ b/src/data/lorcana.ts
@@ -3,29 +3,51 @@ import { buildIndex } from '../lib/elastic';
 import type { Card } from '../types';
 import elasticlunr from 'elasticlunr';
 
-const REMOTE_BASE = 'https://raw.githubusercontent.com/LorcanaJSON/LorcanaJSON/main/EN';
+const SETS = ["TFC","ROTF","ITI","UR","SDS","INKBOUND"];
+const CDN_BASE = 'https://cdn.jsdelivr.net/gh/LorcanaJSON/LorcanaJSON@latest/cards';
+const GITHUB_BASE = 'https://raw.githubusercontent.com/LorcanaJSON/LorcanaJSON/main/EN/cards';
 
-export async function loadCards(): Promise<{ cards: Card[]; index: elasticlunr.Index<Card>; }> {
-  // Try cache
+async function fetchSet(set: string) {
+  const urls = [`${CDN_BASE}/${set}.json`, `${GITHUB_BASE}/${set}.json`];
+  for (const url of urls) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) return await res.json();
+    } catch {
+      // ignore and try next source
+    }
+  }
+  return null;
+}
+
+function normalize(cards: Card[]): Card[] {
+  const map = new Map<number, Card>();
+  for (const card of cards) {
+    if (!map.has(card.id)) map.set(card.id, card);
+  }
+  return Array.from(map.values());
+}
+
+export async function loadCards(): Promise<{ cards: Card[]; index: elasticlunr.Index<Card> }> {
   const cached = await db.cards.toArray();
   if (cached && cached.length) {
     const index = buildIndex(cached);
     return { cards: cached, index };
   }
-  try {
-    const res = await fetch(`${REMOTE_BASE}/allCards.json`);
-    if (res.ok) {
-      const data = await res.json();
-      const cards: Card[] = data.cards || data;
-      await db.cards.bulkPut(cards);
-      const index = buildIndex(cards);
-      return { cards, index };
-    }
-  } catch (e) {
-    console.warn('Remote fetch failed', e);
+
+  let all: Card[] = [];
+  for (const set of SETS) {
+    const data = await fetchSet(set);
+    if (data) all = all.concat(data.cards || data);
   }
-  const local = await fetch('/data/cards.json').then(r => r.json());
-  const cards: Card[] = local;
+
+  if (!all.length) {
+    const local = await fetch('/data/cards.json').then(r => r.json());
+    all = local.cards || local;
+  }
+
+  const cards = normalize(all);
+  if (cards.length) await db.cards.bulkPut(cards);
   const index = buildIndex(cards);
   return { cards, index };
 }

--- a/src/index.css
+++ b/src/index.css
@@ -6,13 +6,4 @@ body {
   color: #f8fafc;
   background-color: #0b1e39;
   min-height: 100vh;
-  background-image: radial-gradient(white, rgba(255,255,255,0.2) 2px, transparent 4px), radial-gradient(white, rgba(255,255,255,0.15) 1px, transparent 3px);
-  background-position: 0 0, 50px 50px;
-  background-size: 100px 100px;
-  animation: stars 60s linear infinite;
-}
-
-@keyframes stars {
-  from { background-position: 0 0, 50px 50px; }
-  to { background-position: -10000px 0, -9950px 50px; }
 }

--- a/src/routes/Builder.tsx
+++ b/src/routes/Builder.tsx
@@ -1,7 +1,8 @@
 import { useEffect } from 'react';
-import { Stack, Typography, List, ListItem, ListItemText, Chip } from '@mui/material';
+import { Stack, Typography, List, ListItem, ListItemText, Chip, Box } from '@mui/material';
 import { useStore } from '../store/useStore';
 import { useDecks } from '../store/useDecks';
+import DeckPreview from '../components/DeckPreview';
 
 export default function Builder() {
   const load = useStore(s => s.load);
@@ -18,16 +19,19 @@ export default function Builder() {
   });
 
   return (
-    <Stack spacing={2}>
-      <Typography variant="h4">Deck Builder</Typography>
-      <List>
-        {entries.map(({ card, count }) => (
-          <ListItem key={card?.id} secondaryAction={<Chip label={count} />}>
-            <ListItemText primary={card?.name || 'Unknown card'} />
-          </ListItem>
-        ))}
-        {entries.length === 0 && <Typography>No cards in deck.</Typography>}
-      </List>
-    </Stack>
+    <Box display="flex" gap={2}">
+      <Stack spacing={2} flex={1}>
+        <Typography variant="h4">Deck Builder</Typography>
+        <List>
+          {entries.map(({ card, count }) => (
+            <ListItem key={card?.id} secondaryAction={<Chip label={count} />}>
+              <ListItemText primary={card?.name || 'Unknown card'} />
+            </ListItem>
+          ))}
+          {entries.length === 0 && <Typography>No cards in deck.</Typography>}
+        </List>
+      </Stack>
+      <DeckPreview />
+    </Box>
   );
 }

--- a/src/routes/Builder.tsx
+++ b/src/routes/Builder.tsx
@@ -1,12 +1,20 @@
-import { useEffect } from 'react';
-import { Stack, Typography, List, ListItem, ListItemText, Chip, Box } from '@mui/material';
-import { useStore } from '../store/useStore';
-import { useDecks } from '../store/useDecks';
-import DeckPreview from '../components/DeckPreview';
+import { useEffect } from "react";
+import {
+  Stack,
+  Typography,
+  List,
+  ListItem,
+  ListItemText,
+  Chip,
+  Box,
+} from "@mui/material";
+import { useStore } from "../store/useStore";
+import { useDecks } from "../store/useDecks";
+import DeckPreview from "../components/DeckPreview";
 
 export default function Builder() {
-  const load = useStore(s => s.load);
-  const cards = useStore(s => s.cards);
+  const load = useStore((s) => s.load);
+  const cards = useStore((s) => s.cards);
   const { deckCards } = useDecks();
 
   useEffect(() => {
@@ -14,18 +22,18 @@ export default function Builder() {
   }, [load]);
 
   const entries = Object.entries(deckCards).map(([id, count]) => {
-    const card = cards.find(c => c.id === Number(id));
+    const card = cards.find((c) => c.id === Number(id));
     return { card, count };
   });
 
   return (
-    <Box display="flex" gap={2}">
+    <Box display="flex" gap={2}>
       <Stack spacing={2} flex={1}>
         <Typography variant="h4">Deck Builder</Typography>
         <List>
           {entries.map(({ card, count }) => (
             <ListItem key={card?.id} secondaryAction={<Chip label={count} />}>
-              <ListItemText primary={card?.name || 'Unknown card'} />
+              <ListItemText primary={card?.name || "Unknown card"} />
             </ListItem>
           ))}
           {entries.length === 0 && <Typography>No cards in deck.</Typography>}

--- a/src/routes/Cards.tsx
+++ b/src/routes/Cards.tsx
@@ -13,10 +13,10 @@ import {
   Stack,
   Typography,
 } from '@mui/material';
-import Masonry from '@mui/lab/Masonry';
 import FilterListIcon from '@mui/icons-material/FilterList';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import CardTile from '../components/CardTile';
+import CardGrid from '../components/CardGrid';
+import DeckPreview from '../components/DeckPreview';
 import { useStore } from '../store/useStore';
 import { useDecks } from '../store/useDecks';
 
@@ -25,7 +25,7 @@ export default function Cards() {
   const cards = useStore(s => s.cards);
   const filters = useStore(s => s.filters);
   const setFilters = useStore(s => s.setFilters);
-  const { addCard, removeCard, countInSelectedDeck, selectedDeckId } = useDecks();
+  const { countInSelectedDeck } = useDecks();
   const indexReady = useStore(s => s.indexReady);
   const query = useStore(s => s.query);
   const [drawerOpen, setDrawerOpen] = useState(false);
@@ -67,21 +67,18 @@ export default function Cards() {
           ))}
         </Stack>
       </Stack>
-      {indexReady ? (
-        <Masonry columns={{ xs: 1, sm: 2, md: 3, lg: 4, xl: 6 }} spacing={2}>
-          {filtered.map(card => (
-            <CardTile
-              key={card.id}
-              card={card}
-              count={countInSelectedDeck(card.id)}
-              onAdd={() => selectedDeckId && addCard(selectedDeckId, card.id)}
-              onRemove={() => selectedDeckId && removeCard(selectedDeckId, card.id)}
-            />
-          ))}
-        </Masonry>
-      ) : (
-        <Typography>Loading...</Typography>
-      )}
+      <Box display="flex" gap={2}>
+        <Box flex={1} minHeight={600}>
+          {indexReady ? (
+            <CardGrid cards={filtered} counts={countInSelectedDeck} />
+          ) : (
+            <Typography>Loading...</Typography>
+          )}
+        </Box>
+        <Box display={{ xs: 'none', md: 'block' }}>
+          <DeckPreview />
+        </Box>
+      </Box>
       <Drawer anchor="left" open={drawerOpen} onClose={() => setDrawerOpen(false)}>
         <Box sx={{ width: 250, p: 2 }}>
           <Accordion defaultExpanded>

--- a/src/store/useDecks.ts
+++ b/src/store/useDecks.ts
@@ -1,15 +1,87 @@
 import { useStore } from './useStore';
-import type { DeckList } from '../types';
+import type { Card } from '../types';
 
 export const useDecks = () => {
-  const selectedDeckId = useStore(s => s.selectedDeckId) || 1;
+  const selectedDeckId = useStore(s => s.selectedDeckId);
+  const decks = useStore(s => s.decks);
   const deckLists = useStore(s => s.deckLists);
-  const addCard = useStore(s => s.addCard);
-  const removeCard = useStore(s => s.removeCard);
+  const cards = useStore(s => s.cards);
 
-  if (!deckLists[selectedDeckId]) deckLists[selectedDeckId] = {};
-  const deckCards: DeckList = deckLists[selectedDeckId];
-  const countInSelectedDeck = (cardId: number) => deckCards[cardId] || 0;
+  const inc = (deckId: number, card: Card) => {
+    useStore.setState(state => {
+      const lists = { ...state.deckLists };
+      const list = { ...(lists[deckId] || {}) };
+      const next = Math.min(4, (list[card.id] || 0) + 1);
+      list[card.id] = next;
+      lists[deckId] = list;
+      return { deckLists: lists };
+    });
+  };
 
-  return { selectedDeckId, addCard, removeCard, deckCards, countInSelectedDeck };
+  const dec = (deckId: number, cardId: number) => {
+    useStore.setState(state => {
+      const lists = { ...state.deckLists };
+      const list = { ...(lists[deckId] || {}) };
+      const next = Math.max(0, (list[cardId] || 0) - 1);
+      if (next === 0) delete list[cardId]; else list[cardId] = next;
+      lists[deckId] = list;
+      return { deckLists: lists };
+    });
+  };
+
+  const addToSelectedOrPrompt = (card: Card) => {
+    let id = useStore.getState().selectedDeckId;
+    if (!id) {
+      const newDeckId = Date.now();
+      const meta = { id: newDeckId, name: 'Quick Deck', createdAt: Date.now(), updatedAt: Date.now() } as any;
+      useStore.setState(state => ({
+        decks: [...state.decks, meta],
+        selectedDeckId: newDeckId,
+        deckLists: { ...state.deckLists, [newDeckId]: {} }
+      }));
+      id = newDeckId;
+    }
+    inc(id!, card);
+  };
+
+  const countInSelectedDeck = (cardId: number) => {
+    const id = useStore.getState().selectedDeckId;
+    if (!id) return 0;
+    return useStore.getState().deckLists[id]?.[cardId] || 0;
+  };
+
+  const deckCards = (deckId?: number) => {
+    const id = deckId ?? useStore.getState().selectedDeckId;
+    if (!id) return [] as Array<{ cardId: string; count: number; snapshot: Card }>;
+    const list = useStore.getState().deckLists[id] || {};
+    return Object.entries(list).map(([cid, count]) => {
+      const snapshot = cards.find(c => c.id === Number(cid)) as Card;
+      return { cardId: cid, count: count as number, snapshot };
+    });
+  };
+
+  function computeStats(rows: { count: number; snapshot: Card }[]) {
+    const stats = {
+      total: 0,
+      inkable: 0,
+      uninkable: 0,
+      types: {} as Record<string, number>,
+      curve: Array.from({ length: 10 }, (_, i) => ({ cost: i < 9 ? String(i) : '9+', count: 0 })),
+    };
+    for (const { count, snapshot } of rows) {
+      stats.total += count;
+      const inkable = snapshot.inkable ?? !(/uninkable/i.test(snapshot.text || ''));
+      if (inkable) stats.inkable += count; else stats.uninkable += count;
+      const type = snapshot.type?.split('/')[0] || 'Other';
+      stats.types[type] = (stats.types[type] || 0) + count;
+      const cost = snapshot.ink_cost ?? 0;
+      const idx = cost >= 9 ? 9 : cost;
+      stats.curve[idx].count += count;
+    }
+    return stats;
+  }
+
+  const stats = () => computeStats(deckCards());
+
+  return { selectedDeckId, inc, dec, addToSelectedOrPrompt, countInSelectedDeck, deckCards, stats };
 };


### PR DESCRIPTION
## Summary
- replace animated background with static aurora gradient
- load cards from CDN with Dexie caching
- add virtualized card grid with deck preview and stats

## Testing
- `npx vitest run --reporter=basic`

------
https://chatgpt.com/codex/tasks/task_e_6895bc5634ec83269587a092f9c658ce