### PR TITLE
Add deck preview panel and virtualized card grid

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,10 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^7.8.0",
-    "zustand": "^5.0.7"
+    "zustand": "^5.0.7",
+    "react-window": "*",
+    "react-virtualized-auto-sizer": "*",
+    "recharts": "*"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.11",

--- a/public/art/aurora-bg.svg
+++ b/public/art/aurora-bg.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1920" height="1080" viewBox="0 0 1920 1080">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#0b1e39"/>
+      <stop offset="100%" stop-color="#1b4366"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="0%" r="70%">
+      <stop offset="0%" stop-color="#a5b4fc" stop-opacity="0.6"/>
+      <stop offset="100%" stop-color="#0b1e39" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#grad)"/>
+  <rect width="100%" height="100%" fill="url(#glow)"/>
+</svg>

--- a/public/art/card-ph.svg
+++ b/public/art/card-ph.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="420" viewBox="0 0 300 420">
+  <rect width="300" height="420" rx="12" ry="12" fill="#1e293b"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="#94a3b8" font-size="20" font-family="sans-serif">No Image</text>
+</svg>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,17 +11,24 @@ import About from './routes/About';
 export default function App() {
   return (
     <BrowserRouter>
-      <Header />
-      <Container maxWidth="xl" sx={{ py: 2 }}>
-        <Routes>
-          <Route path="/" element={<Home />} />
-          <Route path="/cards" element={<Cards />} />
-          <Route path="/card/:id" element={<CardDetails />} />
-          <Route path="/builder" element={<Builder />} />
-          <Route path="/decks" element={<Decks />} />
-          <Route path="/about" element={<About />} />
-        </Routes>
-      </Container>
+      <div className="min-h-screen">
+        <div
+          aria-hidden
+          className="fixed inset-0 -z-10 bg-cover bg-center"
+          style={{ backgroundImage: "url(/art/aurora-bg.svg)" }}
+        />
+        <Header />
+        <Container maxWidth="xl" sx={{ py: 2 }}>
+          <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/cards" element={<Cards />} />
+            <Route path="/card/:id" element={<CardDetails />} />
+            <Route path="/builder" element={<Builder />} />
+            <Route path="/decks" element={<Decks />} />
+            <Route path="/about" element={<About />} />
+          </Routes>
+        </Container>
+      </div>
     </BrowserRouter>
   );
 }

--- a/src/components/CardGrid.tsx
+++ b/src/components/CardGrid.tsx
@@ -1,17 +1,48 @@
-import CardFrame from './CardFrame';
 import type { Card } from '../types';
+import CardTile from './CardTile';
+import { FixedSizeGrid as Grid, GridChildComponentProps } from 'react-window';
+import AutoSizer from 'react-virtualized-auto-sizer';
 
 interface Props {
   cards: Card[];
-  deckId?: number;
+  counts: (id: number) => number;
 }
 
-export default function CardGrid({ cards, deckId }: Props) {
+const CARD_W = 180;
+const CARD_H = 260;
+
+export default function CardGrid({ cards, counts }: Props) {
+  const Cell = ({ columnIndex, rowIndex, style, data }: GridChildComponentProps) => {
+    const { cards, columnCount } = data;
+    const index = rowIndex * columnCount + columnIndex;
+    if (index >= cards.length) return null;
+    const card = cards[index];
+    return (
+      <div style={style} className="p-2">
+        <CardTile card={card} count={counts(card.id)} />
+      </div>
+    );
+  };
+
   return (
-    <div className="grid gap-4 grid-cols-[repeat(auto-fill,minmax(150px,1fr))]">
-      {cards.map(c => (
-        <CardFrame card={c} key={c.id} deckId={deckId} />
-      ))}
-    </div>
+    <AutoSizer>
+      {({ width, height }) => {
+        const columnCount = Math.max(1, Math.floor(width / CARD_W));
+        const rowCount = Math.ceil(cards.length / columnCount);
+        return (
+          <Grid
+            columnCount={columnCount}
+            columnWidth={CARD_W}
+            height={height}
+            rowCount={rowCount}
+            rowHeight={CARD_H}
+            width={width}
+            itemData={{ cards, columnCount }}
+          >
+            {Cell}
+          </Grid>
+        );
+      }}
+    </AutoSizer>
   );
 }

--- a/src/components/CardTile.tsx
+++ b/src/components/CardTile.tsx
@@ -1,36 +1,33 @@
 import { Card as CardType } from '../types';
 import { Card, CardMedia, CardActions, IconButton, Chip, Stack } from '@mui/material';
-import AddIcon from '@mui/icons-material/Add';
 import RemoveIcon from '@mui/icons-material/Remove';
+import { useDecks } from '../store/useDecks';
 
 interface Props {
   card: CardType;
   count: number;
-  onAdd: (id: number) => void;
-  onRemove: (id: number) => void;
 }
 
-export default function CardTile({ card, count, onAdd, onRemove }: Props) {
+export default function CardTile({ card, count }: Props) {
+  const { addToSelectedOrPrompt, dec, selectedDeckId } = useDecks();
+  const handleRemove = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (selectedDeckId) dec(selectedDeckId, card.id);
+  };
+  const src = card.image_url || (card as any).image || '/art/card-ph.svg';
   return (
-    <Card sx={{ position: 'relative' }}>
-      {card.image_url ? (
-        <CardMedia component="img" image={card.image_url} alt={card.name} loading="lazy" />
-      ) : (
-        <CardMedia component="div" sx={{ height: 140, bgcolor: 'grey.800' }} />
-      )}
-      <CardActions sx={{ position: 'absolute', bottom: 0, right: 0 }}>
-        <Stack direction="row" spacing={0.5} alignItems="center">
-          {count > 0 && <Chip label={count} color="primary" size="small" />}
-          <IconButton color="primary" size="small" onClick={() => onAdd(card.id)}>
-            <AddIcon fontSize="small" />
-          </IconButton>
-          {count > 0 && (
-            <IconButton color="primary" size="small" onClick={() => onRemove(card.id)}>
+    <Card sx={{ position: 'relative', cursor: 'pointer' }} onClick={() => addToSelectedOrPrompt(card)}>
+      <CardMedia component="img" image={src} alt={card.name} loading="lazy" width={300} height={420} />
+      {count > 0 && (
+        <CardActions sx={{ position: 'absolute', bottom: 0, right: 0 }}>
+          <Stack direction="row" spacing={0.5} alignItems="center">
+            <Chip label={count} color="primary" size="small" />
+            <IconButton color="primary" size="small" onClick={handleRemove}>
               <RemoveIcon fontSize="small" />
             </IconButton>
-          )}
-        </Stack>
-      </CardActions>
+          </Stack>
+        </CardActions>
+      )}
     </Card>
   );
 }

--- a/src/components/DeckPreview.tsx
+++ b/src/components/DeckPreview.tsx
@@ -1,0 +1,56 @@
+import { Box, Chip, IconButton, Stack, Typography } from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import RemoveIcon from '@mui/icons-material/Remove';
+import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis } from 'recharts';
+import { useDecks } from '../store/useDecks';
+
+export default function DeckPreview() {
+  const { selectedDeckId, deckCards, inc, dec, stats } = useDecks();
+  const rows = deckCards(selectedDeckId || undefined);
+  const s = stats();
+
+  return (
+    <Box sx={{ p: 2, width: 300 }}>
+      <Typography variant="h6" gutterBottom>
+        Deck ({s.total})
+      </Typography>
+      <Stack spacing={1} mb={2}>
+        {rows.map(r => (
+          <Stack key={r.cardId} direction="row" justifyContent="space-between" alignItems="center">
+            <Typography variant="body2" sx={{ flex: 1 }} noWrap>
+              {r.snapshot.name}
+            </Typography>
+            <Stack direction="row" spacing={0.5} alignItems="center">
+              <IconButton size="small" onClick={() => dec(selectedDeckId!, Number(r.cardId))}>
+                <RemoveIcon fontSize="small" />
+              </IconButton>
+              <Chip label={r.count} size="small" />
+              <IconButton size="small" onClick={() => inc(selectedDeckId!, r.snapshot)}>
+                <AddIcon fontSize="small" />
+              </IconButton>
+            </Stack>
+          </Stack>
+        ))}
+        {rows.length === 0 && <Typography variant="body2">No cards</Typography>}
+      </Stack>
+      <Stack direction="row" spacing={1} mb={2}>
+        <Chip label={`Inkable ${s.inkable}`} color="primary" size="small" />
+        <Chip label={`Uninkable ${s.uninkable}`} color="secondary" size="small" />
+      </Stack>
+      <Stack direction="row" spacing={1} flexWrap="wrap" mb={2}>
+        {Object.entries(s.types).map(([t, c]) => (
+          <Chip key={t} label={`${t} ${c}`} size="small" />
+        ))}
+      </Stack>
+      <Box sx={{ height: 120 }}>
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={s.curve}>
+            <XAxis dataKey="cost" />
+            <YAxis allowDecimals={false} />
+            <Bar dataKey="count" fill="#8884d8" />
+          </BarChart>
+        </ResponsiveContainer>
+      </Box>
+    </Box>
+  );
+}

--- a/src/data/lorcana.ts
+++ b/src/data/lorcana.ts
@@ -3,29 +3,51 @@ import { buildIndex } from '../lib/elastic';
 import type { Card } from '../types';
 import elasticlunr from 'elasticlunr';
 
-const REMOTE_BASE = 'https://raw.githubusercontent.com/LorcanaJSON/LorcanaJSON/main/EN';
+const SETS = ["TFC","ROTF","ITI","UR","SDS","INKBOUND"];
+const CDN_BASE = 'https://cdn.jsdelivr.net/gh/LorcanaJSON/LorcanaJSON@latest/cards';
+const GITHUB_BASE = 'https://raw.githubusercontent.com/LorcanaJSON/LorcanaJSON/main/EN/cards';
 
-export async function loadCards(): Promise<{ cards: Card[]; index: elasticlunr.Index<Card>; }> {
-  // Try cache
+async function fetchSet(set: string) {
+  const urls = [`${CDN_BASE}/${set}.json`, `${GITHUB_BASE}/${set}.json`];
+  for (const url of urls) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) return await res.json();
+    } catch {
+      // ignore and try next source
+    }
+  }
+  return null;
+}
+
+function normalize(cards: Card[]): Card[] {
+  const map = new Map<number, Card>();
+  for (const card of cards) {
+    if (!map.has(card.id)) map.set(card.id, card);
+  }
+  return Array.from(map.values());
+}
+
+export async function loadCards(): Promise<{ cards: Card[]; index: elasticlunr.Index<Card> }> {
   const cached = await db.cards.toArray();
   if (cached && cached.length) {
     const index = buildIndex(cached);
     return { cards: cached, index };
   }
-  try {
-    const res = await fetch(`${REMOTE_BASE}/allCards.json`);
-    if (res.ok) {
-      const data = await res.json();
-      const cards: Card[] = data.cards || data;
-      await db.cards.bulkPut(cards);
-      const index = buildIndex(cards);
-      return { cards, index };
-    }
-  } catch (e) {
-    console.warn('Remote fetch failed', e);
+
+  let all: Card[] = [];
+  for (const set of SETS) {
+    const data = await fetchSet(set);
+    if (data) all = all.concat(data.cards || data);
   }
-  const local = await fetch('/data/cards.json').then(r => r.json());
-  const cards: Card[] = local;
+
+  if (!all.length) {
+    const local = await fetch('/data/cards.json').then(r => r.json());
+    all = local.cards || local;
+  }
+
+  const cards = normalize(all);
+  if (cards.length) await db.cards.bulkPut(cards);
   const index = buildIndex(cards);
   return { cards, index };
 }

--- a/src/index.css
+++ b/src/index.css
@@ -6,13 +6,4 @@ body {
   color: #f8fafc;
   background-color: #0b1e39;
   min-height: 100vh;
-  background-image: radial-gradient(white, rgba(255,255,255,0.2) 2px, transparent 4px), radial-gradient(white, rgba(255,255,255,0.15) 1px, transparent 3px);
-  background-position: 0 0, 50px 50px;
-  background-size: 100px 100px;
-  animation: stars 60s linear infinite;
-}
-
-@keyframes stars {
-  from { background-position: 0 0, 50px 50px; }
-  to { background-position: -10000px 0, -9950px 50px; }
 }

--- a/src/routes/Builder.tsx
+++ b/src/routes/Builder.tsx
@@ -1,33 +1,33 @@
 import { useEffect } from 'react';
-import { Stack, Typography, List, ListItem, ListItemText, Chip } from '@mui/material';
+import { Stack, Typography, List, ListItem, ListItemText, Chip, Box } from '@mui/material';
 import { useStore } from '../store/useStore';
 import { useDecks } from '../store/useDecks';
+import DeckPreview from '../components/DeckPreview';
 
 export default function Builder() {
   const load = useStore(s => s.load);
-  const cards = useStore(s => s.cards);
   const { deckCards } = useDecks();
 
   useEffect(() => {
     load();
   }, [load]);
 
-  const entries = Object.entries(deckCards).map(([id, count]) => {
-    const card = cards.find(c => c.id === Number(id));
-    return { card, count };
-  });
+  const entries = deckCards();
 
   return (
-    <Stack spacing={2}>
-      <Typography variant="h4">Deck Builder</Typography>
-      <List>
-        {entries.map(({ card, count }) => (
-          <ListItem key={card?.id} secondaryAction={<Chip label={count} />}>
-            <ListItemText primary={card?.name || 'Unknown card'} />
-          </ListItem>
-        ))}
-        {entries.length === 0 && <Typography>No cards in deck.</Typography>}
-      </List>
-    </Stack>
+    <Box display="flex" gap={2}>
+      <Stack spacing={2} flex={1}>
+        <Typography variant="h4">Deck Builder</Typography>
+        <List>
+          {entries.map(({ snapshot: card, count }) => (
+            <ListItem key={card.id} secondaryAction={<Chip label={count} />}>
+              <ListItemText primary={card.name} />
+            </ListItem>
+          ))}
+          {entries.length === 0 && <Typography>No cards in deck.</Typography>}
+        </List>
+      </Stack>
+      <DeckPreview />
+    </Box>
   );
 }

--- a/src/routes/Cards.tsx
+++ b/src/routes/Cards.tsx
@@ -13,10 +13,10 @@ import {
   Stack,
   Typography,
 } from '@mui/material';
-import Masonry from '@mui/lab/Masonry';
 import FilterListIcon from '@mui/icons-material/FilterList';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import CardTile from '../components/CardTile';
+import CardGrid from '../components/CardGrid';
+import DeckPreview from '../components/DeckPreview';
 import { useStore } from '../store/useStore';
 import { useDecks } from '../store/useDecks';
 
@@ -25,7 +25,7 @@ export default function Cards() {
   const cards = useStore(s => s.cards);
   const filters = useStore(s => s.filters);
   const setFilters = useStore(s => s.setFilters);
-  const { addCard, removeCard, countInSelectedDeck, selectedDeckId } = useDecks();
+  const { countInSelectedDeck } = useDecks();
   const indexReady = useStore(s => s.indexReady);
   const query = useStore(s => s.query);
   const [drawerOpen, setDrawerOpen] = useState(false);
@@ -67,21 +67,18 @@ export default function Cards() {
           ))}
         </Stack>
       </Stack>
-      {indexReady ? (
-        <Masonry columns={{ xs: 1, sm: 2, md: 3, lg: 4, xl: 6 }} spacing={2}>
-          {filtered.map(card => (
-            <CardTile
-              key={card.id}
-              card={card}
-              count={countInSelectedDeck(card.id)}
-              onAdd={() => selectedDeckId && addCard(selectedDeckId, card.id)}
-              onRemove={() => selectedDeckId && removeCard(selectedDeckId, card.id)}
-            />
-          ))}
-        </Masonry>
-      ) : (
-        <Typography>Loading...</Typography>
-      )}
+      <Box display="flex" gap={2}>
+        <Box flex={1} minHeight={600}>
+          {indexReady ? (
+            <CardGrid cards={filtered} counts={countInSelectedDeck} />
+          ) : (
+            <Typography>Loading...</Typography>
+          )}
+        </Box>
+        <Box display={{ xs: 'none', md: 'block' }}>
+          <DeckPreview />
+        </Box>
+      </Box>
       <Drawer anchor="left" open={drawerOpen} onClose={() => setDrawerOpen(false)}>
         <Box sx={{ width: 250, p: 2 }}>
           <Accordion defaultExpanded>

--- a/src/store/useDecks.ts
+++ b/src/store/useDecks.ts
@@ -1,15 +1,87 @@
 import { useStore } from './useStore';
-import type { DeckList } from '../types';
+import type { Card } from '../types';
 
 export const useDecks = () => {
-  const selectedDeckId = useStore(s => s.selectedDeckId) || 1;
+  const selectedDeckId = useStore(s => s.selectedDeckId);
+  const decks = useStore(s => s.decks);
   const deckLists = useStore(s => s.deckLists);
-  const addCard = useStore(s => s.addCard);
-  const removeCard = useStore(s => s.removeCard);
+  const cards = useStore(s => s.cards);
 
-  if (!deckLists[selectedDeckId]) deckLists[selectedDeckId] = {};
-  const deckCards: DeckList = deckLists[selectedDeckId];
-  const countInSelectedDeck = (cardId: number) => deckCards[cardId] || 0;
+  const inc = (deckId: number, card: Card) => {
+    useStore.setState(state => {
+      const lists = { ...state.deckLists };
+      const list = { ...(lists[deckId] || {}) };
+      const next = Math.min(4, (list[card.id] || 0) + 1);
+      list[card.id] = next;
+      lists[deckId] = list;
+      return { deckLists: lists };
+    });
+  };
 
-  return { selectedDeckId, addCard, removeCard, deckCards, countInSelectedDeck };
+  const dec = (deckId: number, cardId: number) => {
+    useStore.setState(state => {
+      const lists = { ...state.deckLists };
+      const list = { ...(lists[deckId] || {}) };
+      const next = Math.max(0, (list[cardId] || 0) - 1);
+      if (next === 0) delete list[cardId]; else list[cardId] = next;
+      lists[deckId] = list;
+      return { deckLists: lists };
+    });
+  };
+
+  const addToSelectedOrPrompt = (card: Card) => {
+    let id = useStore.getState().selectedDeckId;
+    if (!id) {
+      const newDeckId = Date.now();
+      const meta = { id: newDeckId, name: 'Quick Deck', createdAt: Date.now(), updatedAt: Date.now() } as any;
+      useStore.setState(state => ({
+        decks: [...state.decks, meta],
+        selectedDeckId: newDeckId,
+        deckLists: { ...state.deckLists, [newDeckId]: {} }
+      }));
+      id = newDeckId;
+    }
+    inc(id!, card);
+  };
+
+  const countInSelectedDeck = (cardId: number) => {
+    const id = useStore.getState().selectedDeckId;
+    if (!id) return 0;
+    return useStore.getState().deckLists[id]?.[cardId] || 0;
+  };
+
+  const deckCards = (deckId?: number) => {
+    const id = deckId ?? useStore.getState().selectedDeckId;
+    if (!id) return [] as Array<{ cardId: string; count: number; snapshot: Card }>;
+    const list = useStore.getState().deckLists[id] || {};
+    return Object.entries(list).map(([cid, count]) => {
+      const snapshot = cards.find(c => c.id === Number(cid)) as Card;
+      return { cardId: cid, count: count as number, snapshot };
+    });
+  };
+
+  function computeStats(rows: { count: number; snapshot: Card }[]) {
+    const stats = {
+      total: 0,
+      inkable: 0,
+      uninkable: 0,
+      types: {} as Record<string, number>,
+      curve: Array.from({ length: 10 }, (_, i) => ({ cost: i < 9 ? String(i) : '9+', count: 0 })),
+    };
+    for (const { count, snapshot } of rows) {
+      stats.total += count;
+      const inkable = snapshot.inkable ?? !(/uninkable/i.test(snapshot.text || ''));
+      if (inkable) stats.inkable += count; else stats.uninkable += count;
+      const type = snapshot.type?.split('/')[0] || 'Other';
+      stats.types[type] = (stats.types[type] || 0) + count;
+      const cost = snapshot.ink_cost ?? 0;
+      const idx = cost >= 9 ? 9 : cost;
+      stats.curve[idx].count += count;
+    }
+    return stats;
+  }
+
+  const stats = () => computeStats(deckCards());
+
+  return { selectedDeckId, inc, dec, addToSelectedOrPrompt, countInSelectedDeck, deckCards, stats };
 };


### PR DESCRIPTION
## Summary
- replace animated background with static aurora gradient
- load cards from CDN with Dexie caching
- add virtualized card grid with deck preview and stats
- fix builder route deck list syntax causing build error

## Testing
- `npx vitest run --reporter=basic`

------
https://chatgpt.com/codex/tasks/task_e_6895bc5634ec83269587a092f9c658ce