### PR TITLE
refactor: move filters to top and add deck saving

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,6 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { Container } from '@mui/material';
 import Header from './components/Header';
-import Home from './routes/Home';
-import Cards from './routes/Cards';
 import CardDetails from './routes/CardDetails';
 import Builder from './routes/Builder';
 import Decks from './routes/Decks';
@@ -20,10 +18,9 @@ export default function App() {
         <Header />
         <Container maxWidth="xl" sx={{ py: 2 }}>
           <Routes>
-            <Route path="/" element={<Home />} />
-            <Route path="/cards" element={<Cards />} />
-            <Route path="/card/:id" element={<CardDetails />} />
+            <Route path="/" element={<Builder />} />
             <Route path="/builder" element={<Builder />} />
+            <Route path="/card/:id" element={<CardDetails />} />
             <Route path="/decks" element={<Decks />} />
             <Route path="/about" element={<About />} />
           </Routes>

--- a/src/components/CardGrid.tsx
+++ b/src/components/CardGrid.tsx
@@ -5,21 +5,29 @@ import AutoSizer from 'react-virtualized-auto-sizer';
 
 interface Props {
   cards: Card[];
-  counts: (id: number) => number;
+  onCardClick?: (card: Card) => void;
 }
 
-const CARD_W = 180;
-const CARD_H = 260;
+const TILE_W = 240;
+const TILE_H = (240 * 4) / 3 + 56; // 3:4 art + title
+const GAP = 20;
 
-export default function CardGrid({ cards, counts }: Props) {
+export default function CardGrid({ cards, onCardClick }: Props) {
   const Cell = ({ columnIndex, rowIndex, style, data }: GridChildComponentProps) => {
-    const { cards, columnCount } = data;
+    const { cards, columnCount, onCardClick } = data as any;
     const index = rowIndex * columnCount + columnIndex;
     if (index >= cards.length) return null;
     const card = cards[index];
+    const cellStyle: React.CSSProperties = {
+      ...style,
+      left: (style.left as number) + GAP,
+      top: (style.top as number) + GAP,
+      width: TILE_W,
+      height: TILE_H,
+    };
     return (
-      <div style={style} className="p-2">
-        <CardTile card={card} count={counts(card.id)} />
+      <div style={cellStyle}>
+        <CardTile card={card} onCardClick={onCardClick} />
       </div>
     );
   };
@@ -27,17 +35,17 @@ export default function CardGrid({ cards, counts }: Props) {
   return (
     <AutoSizer>
       {({ width, height }) => {
-        const columnCount = Math.max(1, Math.floor(width / CARD_W));
+        const columnCount = Math.max(1, Math.floor((width + GAP) / (TILE_W + GAP)));
         const rowCount = Math.ceil(cards.length / columnCount);
         return (
           <Grid
             columnCount={columnCount}
-            columnWidth={CARD_W}
+            columnWidth={TILE_W + GAP}
             height={height}
             rowCount={rowCount}
-            rowHeight={CARD_H}
+            rowHeight={TILE_H + GAP}
             width={width}
-            itemData={{ cards, columnCount }}
+            itemData={{ cards, columnCount, onCardClick }}
           >
             {Cell}
           </Grid>

--- a/src/components/CardTile.tsx
+++ b/src/components/CardTile.tsx
@@ -1,33 +1,39 @@
 import { Card as CardType } from '../types';
-import { Card, CardMedia, CardActions, IconButton, Chip, Stack } from '@mui/material';
-import RemoveIcon from '@mui/icons-material/Remove';
-import { useDecks } from '../store/useDecks';
+import { Card as MUICard, CardContent, Typography, Chip, Box } from "@mui/material";
 
 interface Props {
   card: CardType;
-  count: number;
+  onCardClick?: (card: CardType) => void;
 }
 
-export default function CardTile({ card, count }: Props) {
-  const { addToSelectedOrPrompt, dec, selectedDeckId } = useDecks();
-  const handleRemove = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    if (selectedDeckId) dec(selectedDeckId, card.id);
-  };
-  const src = card.image_url || (card as any).image || '/art/card-ph.svg';
+export default function CardTile({ card, onCardClick }: Props) {
   return (
-    <Card sx={{ position: 'relative', cursor: 'pointer' }} onClick={() => addToSelectedOrPrompt(card)}>
-      <CardMedia component="img" image={src} alt={card.name} loading="lazy" width={300} height={420} />
-      {count > 0 && (
-        <CardActions sx={{ position: 'absolute', bottom: 0, right: 0 }}>
-          <Stack direction="row" spacing={0.5} alignItems="center">
-            <Chip label={count} color="primary" size="small" />
-            <IconButton color="primary" size="small" onClick={handleRemove}>
-              <RemoveIcon fontSize="small" />
-            </IconButton>
-          </Stack>
-        </CardActions>
-      )}
-    </Card>
+    <MUICard
+      sx={{
+        borderRadius: 3,
+        overflow: "hidden",
+        boxShadow: "0 8px 24px rgba(0,0,0,.35)",
+        transition: "transform .15s ease",
+        "&:hover": { transform: "translateY(-2px)" },
+      }}
+      onClick={()=>onCardClick?.(card)}
+    >
+      <Box sx={{ position:"relative", aspectRatio: "3 / 4", width:"100%" }}>
+        <img
+          src={card.image_url || (card as any).image || "/art/card-ph.svg"}
+          alt={card.name}
+          loading="lazy"
+          width={360}
+          height={480}
+          style={{ width:"100%", height:"100%", objectFit:"cover", display:"block" }}
+        />
+        <Box sx={{ position:"absolute", bottom: 6, left: 6, display:"flex", gap: .5 }}>
+          {!!card.ink_cost && <Chip size="small" label={card.ink_cost >= 9 ? "9+" : String(card.ink_cost)} />}
+        </Box>
+      </Box>
+      <CardContent sx={{ py: 1.25 }}>
+        <Typography variant="subtitle2" noWrap>{card.name}</Typography>
+      </CardContent>
+    </MUICard>
   );
 }

--- a/src/components/DeckPreview.tsx
+++ b/src/components/DeckPreview.tsx
@@ -1,19 +1,27 @@
 import { Box, Chip, IconButton, Stack, Typography } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import RemoveIcon from '@mui/icons-material/Remove';
+import SaveOutlinedIcon from '@mui/icons-material/SaveOutlined';
 import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis } from 'recharts';
 import { useDecks } from '../store/useDecks';
+import { useState } from 'react';
+import SaveDeckDialog from './SaveDeckDialog';
 
 export default function DeckPreview() {
-  const { selectedDeckId, deckCards, inc, dec, stats } = useDecks();
+  const { selectedDeckId, decks, deckCards, inc, dec, stats, saveDeck } = useDecks();
+  const [open, setOpen] = useState(false);
   const rows = deckCards(selectedDeckId || undefined);
   const s = stats();
+  const deck = decks.find(d => d.id === selectedDeckId) || { name: undefined } as any;
 
   return (
     <Box sx={{ p: 2, width: 300 }}>
-      <Typography variant="h6" gutterBottom>
-        Deck ({s.total})
-      </Typography>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5 }}>
+        <Typography variant="h6">{deck.name ?? 'Unsaved Deck'}</Typography>
+        <IconButton size="small" onClick={() => setOpen(true)}>
+          <SaveOutlinedIcon />
+        </IconButton>
+      </Box>
       <Stack spacing={1} mb={2}>
         {rows.map(r => (
           <Stack key={r.cardId} direction="row" justifyContent="space-between" alignItems="center">
@@ -51,6 +59,7 @@ export default function DeckPreview() {
           </BarChart>
         </ResponsiveContainer>
       </Box>
+      <SaveDeckDialog open={open} onClose={() => setOpen(false)} onSave={(name) => saveDeck(name)} />
     </Box>
   );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,4 @@
 import { AppBar, Toolbar, Typography, Button, Stack, Container } from '@mui/material';
-import HomeIcon from '@mui/icons-material/Home';
-import ViewModuleIcon from '@mui/icons-material/ViewModule';
 import BuildIcon from '@mui/icons-material/Build';
 import InfoIcon from '@mui/icons-material/Info';
 import CollectionsIcon from '@mui/icons-material/Collections';
@@ -15,13 +13,7 @@ export default function Header() {
             Lorcana
           </Typography>
           <Stack direction="row" spacing={1}>
-            <Button color="inherit" startIcon={<HomeIcon />} component={RouterLink} to="/">
-              Home
-            </Button>
-            <Button color="inherit" startIcon={<ViewModuleIcon />} component={RouterLink} to="/cards">
-              Cards
-            </Button>
-            <Button color="inherit" startIcon={<BuildIcon />} component={RouterLink} to="/builder">
+            <Button color="inherit" startIcon={<BuildIcon />} component={RouterLink} to="/">
               Builder
             </Button>
             <Button color="inherit" startIcon={<CollectionsIcon />} component={RouterLink} to="/decks">

--- a/src/components/SaveDeckDialog.tsx
+++ b/src/components/SaveDeckDialog.tsx
@@ -1,0 +1,19 @@
+import { Dialog, DialogTitle, DialogContent, DialogActions, Button, TextField } from "@mui/material";
+import { useState, useEffect } from "react";
+
+export default function SaveDeckDialog({ open, onClose, onSave }:{ open:boolean; onClose:()=>void; onSave:(name:string)=>void }) {
+  const [name, setName] = useState("");
+  useEffect(()=>{ if(open) setName(""); }, [open]);
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <DialogTitle>Save Deck</DialogTitle>
+      <DialogContent>
+        <TextField autoFocus fullWidth label="Deck name" value={name} onChange={(e)=>setName(e.target.value)} />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button variant="contained" onClick={()=>{ onSave(name.trim() || "My Deck"); onClose(); }}>Save</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/components/TopFilters.tsx
+++ b/src/components/TopFilters.tsx
@@ -1,0 +1,64 @@
+import { Stack, TextField, ToggleButtonGroup, ToggleButton, Slider, Chip, IconButton, Tooltip } from "@mui/material";
+import FilterAltIcon from "@mui/icons-material/FilterAlt";
+import ClearIcon from "@mui/icons-material/Clear";
+import { useSearch } from "@/store/useSearch";
+
+const INKS = ["Amber","Amethyst","Emerald","Ruby","Sapphire","Steel"] as const;
+
+export default function TopFilters() {
+  const { query, setQuery, filters, setFilters, clearFilters } = useSearch();
+  const cost = filters.cost ?? [1, 9]; // inclusive; 9 means 9+
+
+  const chips = [
+    ...(filters.inks || []).map(i => ({
+      label: i,
+      onDelete: () => setFilters({ inks: (filters.inks || []).filter(x => x !== i) }),
+    })),
+    ...((cost[0] !== 1 || cost[1] !== 9)
+      ? [{ label: `${cost[0]}-${cost[1] === 9 ? '9+' : cost[1]}`, onDelete: () => setFilters({ cost: [1, 9] }) }]
+      : []),
+  ];
+
+  return (
+    <Stack spacing={1} sx={{ mb: 2 }}>
+      <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+        <Tooltip title="Filters"><FilterAltIcon /></Tooltip>
+        <TextField
+          size="small"
+          placeholder="Search cards…"
+          value={query}
+          onChange={(e)=>setQuery(e.target.value)}
+          sx={{ minWidth: 260 }}
+        />
+        <ToggleButtonGroup
+          value={filters.inks || []}
+          onChange={(_, v)=>setFilters({ inks: v })}
+          size="small"
+        >
+          {INKS.map(i=>(<ToggleButton key={i} value={i}>{i.toUpperCase()}</ToggleButton>))}
+        </ToggleButtonGroup>
+        <Stack direction="row" alignItems="center" spacing={1} sx={{ minWidth: 220 }}>
+          <Chip size="small" label="Cost" />
+          <Slider
+            size="small"
+            min={1}
+            max={9}
+            value={cost}
+            onChange={(_, v)=>setFilters({ cost: v as number[] })}
+            valueLabelDisplay="auto"
+            valueLabelFormat={(v)=> v===9 ? "9+" : v}
+            marks={[{value:1,label:"1"},{value:3,label:"3"},{value:5,label:"5"},{value:7,label:"7"},{value:9,label:"9+"}]}
+          />
+        </Stack>
+        <IconButton size="small" onClick={clearFilters}><ClearIcon/></IconButton>
+      </Stack>
+      {chips.length > 0 && (
+        <Stack direction="row" spacing={1} flexWrap="wrap">
+          {chips.map(c => (
+            <Chip key={c.label} label={c.label} onDelete={c.onDelete} size="small" />
+          ))}
+        </Stack>
+      )}
+    </Stack>
+  );
+}

--- a/src/routes/Builder.tsx
+++ b/src/routes/Builder.tsx
@@ -1,33 +1,49 @@
-import { useEffect } from 'react';
-import { Stack, Typography, List, ListItem, ListItemText, Chip, Box } from '@mui/material';
-import { useStore } from '../store/useStore';
-import { useDecks } from '../store/useDecks';
-import DeckPreview from '../components/DeckPreview';
+import { useEffect, useState } from 'react';
+import { Box, Typography, IconButton, Dialog } from '@mui/material';
+import CollectionsIcon from '@mui/icons-material/Collections';
+import TopFilters from '@/components/TopFilters';
+import CardGrid from '@/components/CardGrid';
+import DeckPreview from '@/components/DeckPreview';
+import { useStore } from '@/store/useStore';
+import { useDecks } from '@/store/useDecks';
+import { useSearch } from '@/store/useSearch';
 
 export default function Builder() {
   const load = useStore(s => s.load);
-  const { deckCards } = useDecks();
+  const indexReady = useStore(s => s.indexReady);
+  const { addToSelectedOrPrompt } = useDecks();
+  const results = useSearch(s => s.results());
+  const [open, setOpen] = useState(false);
 
   useEffect(() => {
     load();
   }, [load]);
 
-  const entries = deckCards();
-
   return (
-    <Box display="flex" gap={2}>
-      <Stack spacing={2} flex={1}>
-        <Typography variant="h4">Deck Builder</Typography>
-        <List>
-          {entries.map(({ snapshot: card, count }) => (
-            <ListItem key={card.id} secondaryAction={<Chip label={count} />}>
-              <ListItemText primary={card.name} />
-            </ListItem>
-          ))}
-          {entries.length === 0 && <Typography>No cards in deck.</Typography>}
-        </List>
-      </Stack>
-      <DeckPreview />
+    <Box>
+      <TopFilters />
+      <Box display="flex" gap={2}>
+        <Box flex={1} minHeight={600}>
+          {indexReady ? (
+            <CardGrid cards={results} onCardClick={addToSelectedOrPrompt} />
+          ) : (
+            <Typography>Loading...</Typography>
+          )}
+        </Box>
+        <Box sx={{ display: { xs: 'none', md: 'block' }, position: 'sticky', top: 0 }}>
+          <DeckPreview />
+        </Box>
+      </Box>
+      <IconButton
+        color="primary"
+        onClick={() => setOpen(true)}
+        sx={{ position: 'fixed', bottom: 16, right: 16, display: { xs: 'inline-flex', md: 'none' } }}
+      >
+        <CollectionsIcon />
+      </IconButton>
+      <Dialog open={open} onClose={() => setOpen(false)} fullScreen>
+        <DeckPreview />
+      </Dialog>
     </Box>
   );
 }

--- a/src/store/useSearch.ts
+++ b/src/store/useSearch.ts
@@ -1,0 +1,45 @@
+import { create } from 'zustand';
+import { useStore } from './useStore';
+import type { Card } from '../types';
+
+interface Filters {
+  inks: string[];
+  cost: [number, number];
+}
+
+interface SearchState {
+  query: string;
+  setQuery: (q: string) => void;
+  filters: Filters;
+  setFilters: (f: Partial<Filters>) => void;
+  clearFilters: () => void;
+  results: () => Card[];
+}
+
+const DEFAULT_FILTERS: Filters = { inks: [], cost: [1, 9] };
+
+export const useSearch = create<SearchState>((set, get) => ({
+  query: '',
+  setQuery: (q: string) => set({ query: q }),
+  filters: DEFAULT_FILTERS,
+  setFilters: (f: Partial<Filters>) => set({ filters: { ...get().filters, ...f } }),
+  clearFilters: () => set({ query: '', filters: DEFAULT_FILTERS }),
+  results: () => {
+    const { query, filters } = get();
+    const store = useStore.getState();
+    const cards = store.cards;
+    let result = query ? store.search(query) : cards;
+    if (filters.inks.length) {
+      result = result.filter(c => filters.inks.includes(c.ink));
+    }
+    const [lo, hi] = filters.cost;
+    if (lo !== 1 || hi !== 9) {
+      result = result.filter(c => {
+        const val = Number(c.ink_cost ?? 0);
+        if (hi === 9) return val >= lo;
+        return val >= lo && val <= hi;
+      });
+    }
+    return result;
+  },
+}));


### PR DESCRIPTION
## Summary
- replace slide-out filters with top bar using new search store
- restyle card tiles and grid spacing
- make builder the main page with deck saving dialog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895c3db7eb4832698482a78c70f3a24